### PR TITLE
添加 self.lang 初始化

### DIFF
--- a/productai/__init__.py
+++ b/productai/__init__.py
@@ -31,6 +31,7 @@ class Client(object):
         if not session:
             session = get_default_session()
         self.session = session
+        self.lang = None
 
     def get_api(self, type_, id_):
         return API(self, type_, id_)

--- a/productai/__init__.py
+++ b/productai/__init__.py
@@ -31,7 +31,7 @@ class Client(object):
         if not session:
             session = get_default_session()
         self.session = session
-        self.lang = None
+        self.lang = 'en-us'
 
     def get_api(self, type_, id_):
         return API(self, type_, id_)

--- a/productai/__init__.py
+++ b/productai/__init__.py
@@ -304,11 +304,11 @@ def _normalize_images_file(x, tmpdir=None):
 
 
 def date_str(d):
-    date_format = "%Y-%m-%d"
+    date_format = "%Y-%m-%dT%H:%M:%SZ"
     if isinstance(d, six.string_types):
         dt.datetime.strptime(d, date_format)  # format check
         return d
     elif isinstance(d, (dt.date, dt.datetime)):
-        return d.strftime('%Y-%m-%d')
+        return d.strftime(date_format)
     else:
         raise TypeError("Invalid date %r" % d)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,8 +51,8 @@ def test_calc_signature(mocker):
 
 
 def test_date_str():
-    d = dt.date(2015, 1, 11)
-    assert m.date_str(d) == '2015-01-11'
+    d = dt.datetime(2015, 1, 11, 12, 13, 14)
+    assert m.date_str(d) == '2015-01-11T12:13:14Z'
     with pytest.raises(ValueError):
         m.date_str('asdfasdf')
-    assert m.date_str(dt.datetime(2017, 2, 10)) == '2017-02-10'
+    assert m.date_str(dt.datetime(2017, 2, 10, 12, 13, 14)) == '2017-02-10T12:13:14Z'


### PR DESCRIPTION
若 set_lang 没被调用， self.lang 不会被初始化，从而导致报错。
在构造函数中添加 self.lang 初始化