### PR TITLE
fix bulk operations operating on closed file in ImageSetAPI

### DIFF
--- a/productai/__init__.py
+++ b/productai/__init__.py
@@ -308,12 +308,12 @@ class ImageSetAPI(API):
         '''批量添加图片'''
         with _normalize_items_file(img_infos) as f:
             files = {'urls_to_add': f}
-        return self.client.post(self.base_url, files=files)
+            return self.client.post(self.base_url, files=files)
 
     def delete_images_in_bulk(self, img_infos):
         with _normalize_items_file(img_infos) as f:
             files = {'urls_to_delete': f}
-        return self.client.post(self.base_url, files=files)
+            return self.client.post(self.base_url, files=files)
 
     def add_image(self, image_url, meta=None, tags=''):
         form = {'image_url': image_url, 'meta': meta, 'tags': tags}


### PR DESCRIPTION
When trying to perfom a bulk operation using either a list or file
name you get the following ValueError:
```
ValueError: I/O operation on closed file.
```

The context manager `_normalize_items_file` creates a temp file (or
read an existing file) and yield the open file.
The request to the API was not executed inside the context so the file
is closed before the request is actually made.

Fix was to move the call into the context.